### PR TITLE
Remove macros that generate formatting code

### DIFF
--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -1,6 +1,7 @@
 use crate::ckb_constants::*;
 use crate::error::SysError;
 use crate::syscalls;
+use crate::debug;
 use alloc::vec::Vec;
 use ckb_types::{packed::*, prelude::*};
 
@@ -497,7 +498,10 @@ impl<T, F: Fn(usize, Source) -> Result<T, SysError>> Iterator for QueryIter<F> {
                 Some(item)
             }
             Err(SysError::IndexOutOfBound) => None,
-            Err(err) => panic!("{:?}", err),
+            Err(err) => {
+                debug!("QueryIter error {:?}", err);
+                panic!("QueryIter query_fn return an error")
+            }
         }
     }
 }


### PR DESCRIPTION
This PR try to reduce binary size by removing formatting code in `ckb-std`.
A simple contract can reduce the size from ~26K to ~13K.

See details in this article [fmt unreasonably expensive](https://jamesmunns.com/blog/fmt-unreasonably-expensive/)