### PR TITLE
Add -Wno-dangling-pointer

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,7 @@ fn main() {
             .define("__SHARED_LIBRARY__", None)
             .flag("-Wno-nonnull-compare")
             .flag("-nostartfiles")
+            .flag("-Wno-dangling-pointer")
             .compile("dl-c-impl");
     }
 }


### PR DESCRIPTION
gcc added dangling-pointer checks in 12.1, which caused ckb-std to fail to compile.

```
the following warnings were emitted during compilation:

warning: In file included from dl-c-impl/ckb-c-stdlib/libc/entry.h:5,
warning:                  from dl-c-impl/ckb-c-stdlib/libc/stddef.h:6,
warning:                  from dl-c-impl/ckb-c-stdlib/ckb_syscalls.h:4,
warning:                  from dl-c-impl/ckb-c-stdlib/ckb_dlfcn.h:4,
warning:                  from dl-c-impl/lib.c:5:
warning: dl-c-impl/ckb-c-stdlib/libc/src/impl.c: In function 'cycle':
warning: dl-c-impl/ckb-c-stdlib/libc/src/impl.c:391:9: error: storing the address of local variable 'tmp' in '*ar_32(D) + _2' [-Werror=dangling-pointer=]
warning:   391 |   ar[n] = tmp;
warning:       |   ~~~~~~^~~~~
warning: dl-c-impl/ckb-c-stdlib/libc/src/impl.c:383:17: note: 'tmp' declared here
warning:   383 |   unsigned char tmp[256];
warning:       |                 ^~~
warning: dl-c-impl/ckb-c-stdlib/libc/src/impl.c:383:17: note: 'ar' declared here
warning: cc1: all warnings being treated as errors

error: failed to run custom build command for `ckb-std v0.10.0 (/tmp/ckb-std)`
```