### PR TITLE
feat: Adapt ckb-std for usage in rustc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ jobs:
       run: git submodule update --init --recursive
     - name: Install Rust target
       run: rustup target add riscv64imac-unknown-none-elf
+    - name: Build without riscv C compiler
+      run: cargo build --target=riscv64imac-unknown-none-elf --no-default-features --features=ckb-types,allocator
     - name: Install tools
       run: make install-tools
     - name: Run integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default = ["allocator", "ckb-types", "dlopen-c"]
 allocator = [ "buddy-alloc" ]
 simulator = [ "ckb-x64-simulator" ]
 dlopen-c = []
+link-dummy-libc = []
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,17 @@ default = ["allocator", "ckb-types", "dlopen-c"]
 allocator = [ "buddy-alloc" ]
 simulator = [ "ckb-x64-simulator" ]
 dlopen-c = []
-link-dummy-libc = []
+ckb-os = []
+rustc-dep-of-std = ["alloc", "core", "compiler_builtins/rustc-dep-of-std", "buddy-alloc/rustc-dep-of-std"]
 
 [build-dependencies]
 cc = "1.0"
 
 [dependencies]
 ckb-types = { package = "ckb-standalone-types", version = "0.1.2", default-features = false, optional = true }
-buddy-alloc = { version = "0.4.1", optional = true }
+buddy-alloc = { version = "0.4.2", optional = true }
 ckb-x64-simulator = { version = "0.7.0", optional = true }
+
+alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+compiler_builtins = { version = "0.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,3 @@ cc = "1.0"
 ckb-types = { package = "ckb-standalone-types", version = "0.1.2", default-features = false, optional = true }
 buddy-alloc = { version = "0.4.1", optional = true }
 ckb-x64-simulator = { version = "0.7.0", optional = true }
-naked-function = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ exclude = ["docs"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["allocator", "ckb-types"]
+default = ["allocator", "ckb-types", "dlopen-c"]
 allocator = [ "buddy-alloc" ]
 simulator = [ "ckb-x64-simulator" ]
+dlopen-c = []
 
 [build-dependencies]
 cc = "1.0"
@@ -22,3 +23,4 @@ cc = "1.0"
 ckb-types = { package = "ckb-standalone-types", version = "0.1.2", default-features = false, optional = true }
 buddy-alloc = { version = "0.4.1", optional = true }
 ckb-x64-simulator = { version = "0.7.0", optional = true }
+naked-function = "0.1.2"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::env;
 
 fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     // ckb-std only supports riscv64 target arch
     // but we can still use cargo check under other archs
@@ -30,7 +31,12 @@ fn main() {
             .compile("dl-c-impl");
     }
 
-    if target_arch == "riscv64" && cfg!(feature = "link-dummy-libc") {
+    if cfg!(feature = "ckb-os") {
+        if target_arch != "riscv64" || target_os != "ckb" {
+            panic!(
+                "ckb-os can only be enabled when compiling for riscv64*-unknown-ckb-elf targets!"
+            );
+        }
         println!("cargo:rustc-link-lib=dummylibc");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -5,10 +5,7 @@ fn main() {
 
     // ckb-std only supports riscv64 target arch
     // but we can still use cargo check under other archs
-    if target_arch == "riscv64" {
-        cc::Build::new()
-            .file("src/asm/syscall.S")
-            .compile("ckb-syscall");
+    if target_arch == "riscv64" && cfg!(feature = "dlopen-c") {
         cc::Build::new()
             .file("dl-c-impl/lib.c")
             .static_flag(true)

--- a/build.rs
+++ b/build.rs
@@ -29,4 +29,8 @@ fn main() {
             .flag("-Wno-dangling-pointer")
             .compile("dl-c-impl");
     }
+
+    if target_arch == "riscv64" && cfg!(feature = "link-dummy-libc") {
+        println!("cargo:rustc-link-lib=dummylibc");
+    }
 }

--- a/src/asm/syscall.S
+++ b/src/asm/syscall.S
@@ -1,6 +1,0 @@
-.text
-.globl syscall
-
-syscall:
-    ecall
-    ret

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -11,6 +11,7 @@
 ///    0
 /// }
 /// ```
+#[cfg(not(feature = "ckb-os"))]
 #[macro_export]
 macro_rules! entry {
     ($main:path) => {
@@ -95,3 +96,15 @@ macro_rules! entry {
         }
     };
 }
+
+#[cfg(feature = "ckb-os")]
+core::arch::global_asm!(
+    ".global _start",
+    "_start:",
+    "lw a0, 0(sp)",
+    "addi a1, sp, 8",
+    "li a2, 0",
+    "call main",
+    "li a7, 93",
+    "ecall",
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod syscalls;
 #[cfg(feature = "ckb-types")]
 pub use ckb_types;
 pub mod dynamic_loading;
-#[cfg(target_arch = "riscv64")]
+#[cfg(all(target_arch = "riscv64", feature = "dlopen-c"))]
 pub mod dynamic_loading_c_impl;
 #[cfg(feature = "allocator")]
 pub use buddy_alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![no_std]
 
+#[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
 
 pub mod ckb_constants;
@@ -24,6 +25,7 @@ pub mod since;
 pub mod syscalls;
 #[cfg(feature = "ckb-types")]
 pub use ckb_types;
+#[cfg(feature = "ckb-types")]
 pub mod dynamic_loading;
 #[cfg(all(target_arch = "riscv64", feature = "dlopen-c"))]
 pub mod dynamic_loading_c_impl;

--- a/src/syscalls/native.rs
+++ b/src/syscalls/native.rs
@@ -2,9 +2,21 @@ use crate::{ckb_constants::*, error::SysError};
 use core::ffi::CStr;
 
 #[cfg(target_arch = "riscv64")]
-#[link(name = "ckb-syscall")]
-extern "C" {
-    fn syscall(a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64, a6: u64, a7: u64) -> u64;
+#[naked_function::naked]
+unsafe extern "C" fn syscall(
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+    a6: u64,
+    a7: u64,
+) -> u64 {
+    asm!(
+        "ecall",
+        "ret",
+    );
 }
 
 #[cfg(not(target_arch = "riscv64"))]

--- a/src/syscalls/native.rs
+++ b/src/syscalls/native.rs
@@ -3,7 +3,7 @@ use core::arch::asm;
 use core::ffi::CStr;
 
 #[cfg(target_arch = "riscv64")]
-unsafe extern "C" fn syscall(
+unsafe fn syscall(
     mut a0: u64,
     a1: u64,
     a2: u64,

--- a/src/syscalls/native.rs
+++ b/src/syscalls/native.rs
@@ -1,10 +1,10 @@
 use crate::{ckb_constants::*, error::SysError};
+use core::arch::asm;
 use core::ffi::CStr;
 
 #[cfg(target_arch = "riscv64")]
-#[naked_function::naked]
 unsafe extern "C" fn syscall(
-    a0: u64,
+    mut a0: u64,
     a1: u64,
     a2: u64,
     a3: u64,
@@ -14,9 +14,17 @@ unsafe extern "C" fn syscall(
     a7: u64,
 ) -> u64 {
     asm!(
-        "ecall",
-        "ret",
+      "ecall",
+      inout("a0") a0,
+      in("a1") a1,
+      in("a2") a2,
+      in("a3") a3,
+      in("a4") a4,
+      in("a5") a5,
+      in("a6") a6,
+      in("a7") a7
     );
+    a0
 }
 
 #[cfg(not(target_arch = "riscv64"))]


### PR DESCRIPTION
This commit adds the following change to remove the dependency on gcc:

* Rewrite `syscall` as an extern C function
* Introduce a new feature `dlopen-c` which controls the presence of C based dlopen. This feature is enabled by default so as not to introduce any breaking changes
* Introduce a new feature `ckb-os` which can enable `std` in CKB environment with a custom-patched rustc
