### PR TITLE
fix: Revise ckb-std's feature linking logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ allocator = [ "buddy-alloc" ]
 simulator = [ "ckb-x64-simulator" ]
 dlopen-c = []
 ckb-os = []
+no-dummy-libc = []
 rustc-dep-of-std = ["alloc", "core", "compiler_builtins/rustc-dep-of-std", "buddy-alloc/rustc-dep-of-std"]
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ exclude = ["docs"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["allocator", "ckb-types", "dlopen-c"]
+default = ["allocator", "ckb-types", "dlopen-c", "dummy-libc"]
 allocator = [ "buddy-alloc" ]
 simulator = [ "ckb-x64-simulator" ]
 dlopen-c = []
-no-dummy-libc = []
+dummy-libc = []
 rustc-dep-of-std = ["alloc", "core", "compiler_builtins/rustc-dep-of-std", "buddy-alloc/rustc-dep-of-std"]
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ default = ["allocator", "ckb-types", "dlopen-c"]
 allocator = [ "buddy-alloc" ]
 simulator = [ "ckb-x64-simulator" ]
 dlopen-c = []
-ckb-os = []
 no-dummy-libc = []
 rustc-dep-of-std = ["alloc", "core", "compiler_builtins/rustc-dep-of-std", "buddy-alloc/rustc-dep-of-std"]
 

--- a/build.rs
+++ b/build.rs
@@ -31,8 +31,7 @@ fn main() {
             .compile("dl-c-impl");
     }
 
-    if target_arch == "riscv64" && target_os == "ckb" && (!cfg!(feature = "no-linking-dummy-libc"))
-    {
+    if target_arch == "riscv64" && target_os == "ckb" && (!cfg!(feature = "no-dummy-libc")) {
         println!("cargo:rustc-link-lib=dummylibc");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -31,14 +31,6 @@ fn main() {
             .compile("dl-c-impl");
     }
 
-    if cfg!(feature = "ckb-os") {
-        if target_arch != "riscv64" || target_os != "ckb" {
-            panic!(
-                "ckb-os can only be enabled when compiling for riscv64*-unknown-ckb-elf targets!"
-            );
-        }
-    }
-
     if target_arch == "riscv64" && target_os == "ckb" && (!cfg!(feature = "no-linking-dummy-libc"))
     {
         println!("cargo:rustc-link-lib=dummylibc");

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,10 @@ fn main() {
                 "ckb-os can only be enabled when compiling for riscv64*-unknown-ckb-elf targets!"
             );
         }
+    }
+
+    if target_arch == "riscv64" && target_os == "ckb" && (!cfg!(feature = "no-linking-dummy-libc"))
+    {
         println!("cargo:rustc-link-lib=dummylibc");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,7 @@ fn main() {
             .compile("dl-c-impl");
     }
 
-    if target_arch == "riscv64" && target_os == "ckb" && (!cfg!(feature = "no-dummy-libc")) {
+    if target_arch == "riscv64" && target_os == "ckb" && cfg!(feature = "dummy-libc") {
         println!("cargo:rustc-link-lib=dummylibc");
     }
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -11,7 +11,6 @@
 ///    0
 /// }
 /// ```
-#[cfg(not(feature = "ckb-os"))]
 #[macro_export]
 macro_rules! entry {
     ($main:path) => {
@@ -96,15 +95,3 @@ macro_rules! entry {
         }
     };
 }
-
-#[cfg(feature = "ckb-os")]
-core::arch::global_asm!(
-    ".global _start",
-    "_start:",
-    "lw a0, 0(sp)",
-    "addi a1, sp, 8",
-    "li a2, 0",
-    "call main",
-    "li a7, 93",
-    "ecall",
-);


### PR DESCRIPTION
Previously, a new feature `ckb-os` is added to ckb-std, CKB's Rust std fork will then enable this feature, controlling the behavior of `ckb-std`.

However, this does not really play well in practice. I have revised the logic here and remove`ckb-os` feature from ckb-std, the relavant logic will be moved to CKB's Rust std fork. This way we can keep ckb-std relatively simple.

There is still a problem left in `no_std` mode: when the C implementation of dlopen becomes a feature, disabling `dlopen-c` will mean that ckb-std does not ship with stubs for memcpy/memcmp/memset, etc. This will unexpectedly break some existing code. As a result, a new feature `dummy-libc` is added here, so when `target_os` is `ckb`(meaning dummy libc is available), enabling `dummy-libc` will tell ckb-std to link against dummy libc library, providing the missing common libc functions. Note this is provided as a feature(but enabled by default) considering there might be other code that ship with libc code themselves.