### PR TITLE
chore: hide empty modules from doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,13 @@
 extern crate alloc;
 
 pub mod ckb_constants;
+#[doc(hidden)]
 pub mod debug;
+#[doc(hidden)]
 pub mod entry;
 pub mod env;
 pub mod error;
+#[doc(hidden)]
 pub mod global_alloc_macro;
 #[cfg(feature = "ckb-types")]
 pub mod high_level;


### PR DESCRIPTION
These modules only contain macros, which are all exported under the crate global namespace.