### PR TITLE
chore: fix cargo doc warnings

### DIFF
--- a/src/dynamic_loading.rs
+++ b/src/dynamic_loading.rs
@@ -61,10 +61,10 @@
 //! ```
 //!
 //! The core part of this module is inspired from
-//! https://github.com/nervosnetwork/ckb-c-stdlib/blob/eae8c4c974ce68ca8062521747a16e8e59de755f/ckb_dlfcn.h
+//! <https://github.com/nervosnetwork/ckb-c-stdlib/blob/eae8c4c974ce68ca8062521747a16e8e59de755f/ckb_dlfcn.h>
 //!
 //! The ELF parsing code is inspired from
-//! https://github.com/riscv/riscv-pk/blob/master/pk/elf.h
+//! <https://github.com/riscv/riscv-pk/blob/master/pk/elf.h>
 //! original code is in BSD license.
 
 use crate::ckb_constants::Source;

--- a/src/syscalls/native.rs
+++ b/src/syscalls/native.rs
@@ -537,7 +537,7 @@ pub fn current_cycles() -> u64 {
 /// by those of the new program. It's cycles consumption consists of two parts:
 ///
 /// - Fixed 500 cycles
-/// - Initial Loading Cycles (https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0014-vm-cycle-limits/0014-vm-cycle-limits.md)
+/// - Initial Loading Cycles (<https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0014-vm-cycle-limits/0014-vm-cycle-limits.md>)
 ///
 /// The arguments used here are:
 ///


### PR DESCRIPTION
Quote links in doc like this: `<https://example.com>`.