### PR TITLE
docs: use doc_auto_cfg on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ description = "This library contains serveral modules help you write CKB contrac
 exclude = ["docs"]
 
 [package.metadata.docs.rs]
-all-features = true
+# All features except simulator and rustc-dep-of-std.
+features = ["allocator", "ckb-types", "dlopen-c", "dummy-libc", "ckb2023"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! * `default_alloc!` and `libc_alloc!` macro: defines global allocator for no-std rust
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;


### PR DESCRIPTION
Enable `doc_auto_cfg` on docs.rs. And don't actually include all features. Simulator and rustc-dep-of-std shouldn't be enabled.

Test/preview locally with

```
RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --features=ckb2023 --open
```
