### PR TITLE
chore: upgrade toolchain

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-std"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "buddy-alloc",
  "cc",

--- a/contracts/ckb-std-tests/src/code_hashes.rs
+++ b/contracts/ckb-std-tests/src/code_hashes.rs
@@ -1,4 +1,6 @@
+// this is a blake2b hash of the shared library `test/shared-lib/shared-lib.so`
+// remember to update this hash if you change the shared library or upgrade the toolchain
 pub const CODE_HASH_SHARED_LIB: [u8; 32] = [
-    235, 179, 185, 44, 159, 213, 242, 94, 42, 196, 68, 5, 213, 248, 71, 106, 136, 183, 99, 125, 37,
-    214, 63, 59, 57, 87, 65, 80, 177, 92, 23, 255,
+    225, 15, 172, 171, 171, 161, 4, 34, 170, 83, 228, 192, 169, 205, 29, 189, 112, 156, 164, 73,
+    222, 132, 215, 23, 163, 71, 194, 190, 4, 227, 187, 120,
 ];

--- a/contracts/ckb-std-tests/src/entry.rs
+++ b/contracts/ckb-std-tests/src/entry.rs
@@ -3,8 +3,8 @@ use alloc::vec::Vec;
 use blake2b_ref::{Blake2b, Blake2bBuilder};
 #[allow(unused_imports)]
 use ckb_std::{
-    ckb_constants::*, ckb_types::prelude::*, debug, error::SysError, high_level, syscalls,
-    ckb_types::core::ScriptHashType
+    ckb_constants::*, ckb_types::core::ScriptHashType, ckb_types::prelude::*, debug,
+    error::SysError, high_level, syscalls,
 };
 use core::mem::size_of;
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -13,7 +13,7 @@
 /// [logger]
 /// filter = "info,ckb-script=debug"
 /// ```
-/// 
+///
 /// See the essay on more [Tips for Debugging CKB Scripts](https://docs.nervos.org/docs/essays/debug).
 ///
 /// # Example

--- a/test/shared-lib/Makefile
+++ b/test/shared-lib/Makefile
@@ -5,8 +5,8 @@ OBJCOPY := $(TARGET)-objcopy
 CFLAGS := -fPIC -O3 -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/libc -I deps -I deps/molecule -I c -I build -I deps/secp256k1/src -I deps/secp256k1 -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
 LDFLAGS := -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections
 
-# docker pull nervos/ckb-riscv-gnu-toolchain:gnu-bionic-20191012
-BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:aae8a3f79705f67d505d1f1d5ddc694a4fd537ed1c7e9622420a470d59ba2ec3
+# docker pull nervos/ckb-riscv-gnu-toolchain:gnu-focal-20230214
+BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:7bc4e566f293b6c3d9740cf04fc5861b2f0acc268ca3a025fcf9446f1ab5f27d
 
 all-via-docker:
 	docker run --rm -v `pwd`:/code ${BUILDER_DOCKER} bash -c "cd /code && make shared-lib.so"
@@ -15,4 +15,3 @@ shared-lib.so: shared-lib.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $<
 	$(OBJCOPY) --only-keep-debug $@ $@.debug
 	$(OBJCOPY) --strip-debug --strip-all $@
-


### PR DESCRIPTION
update unit test's toolchain to the same version as capsule template