### PR TITLE
Refactor high_level::exec_cell api

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,6 @@ jobs:
     - name: Check example
       run: cross check --examples
     - name: Install capsule
-      run: cargo install ckb-capsule --git https://github.com/nervosnetwork/capsule --rev ccd6a7c39f0e
+      run: cargo install ckb-capsule --git https://github.com/nervosnetwork/capsule --rev 5c1b2ce
     - name: Run tests
       run: make test

--- a/capsule.toml
+++ b/capsule.toml
@@ -1,6 +1,5 @@
-# We are actually using unreleased features in capsule. Use 0.10 after it's released.
 # capsule version
-version = "0.9.1"
+version = "0.10.0"
 # path of deployment config file
 deployment = "deployment.toml"
 

--- a/contracts/exec-caller-by-code-hash/src/entry.rs
+++ b/contracts/exec-caller-by-code-hash/src/entry.rs
@@ -15,11 +15,10 @@ pub fn main() -> Result<(), Error> {
     let arg2 = CStr::from_bytes_with_nul("你好\0".as_bytes()).unwrap();
     let code_hash = load_script().unwrap().args().raw_data();
     ckb_std::debug!("code_hash: {:?}", code_hash);
-    let ret = high_level::exec_cell(
+    high_level::exec_cell(
         &code_hash[..],
         ScriptHashType::Data1,
         &[arg1, arg2][..],
-    )
-    .unwrap();
-    panic!("exec failed: {}", ret);
+    )?;
+    unreachable!()
 }

--- a/contracts/exec-caller-by-code-hash/src/entry.rs
+++ b/contracts/exec-caller-by-code-hash/src/entry.rs
@@ -18,8 +18,6 @@ pub fn main() -> Result<(), Error> {
     let ret = high_level::exec_cell(
         &code_hash[..],
         ScriptHashType::Data1,
-        0,
-        0,
         &[arg1, arg2][..],
     )
     .unwrap();

--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -625,15 +625,12 @@ pub fn look_for_dep_with_data_hash(data_hash: &[u8]) -> Result<usize, SysError> 
 pub fn exec_cell(
     code_hash: &[u8],
     hash_type: ScriptHashType,
-    offset: u32,
-    length: u32,
     argv: &[&CStr],
 ) -> Result<Infallible, SysError> {
     #[cfg(not(feature = "simulator"))]
     {
         let index = look_for_dep_with_hash2(code_hash, hash_type)?;
-        let bounds: usize = (offset as usize) << 32 | (length as usize);
-        let ret = syscalls::exec(index, Source::CellDep, 0, bounds, argv);
+        let ret = syscalls::exec(index, Source::CellDep, 0, 0, argv);
         let err = match ret {
             1 => SysError::IndexOutOfBound,
             2 => SysError::ItemMissing,
@@ -642,7 +639,7 @@ pub fn exec_cell(
         Err(err)
     }
     #[cfg(feature = "simulator")]
-    syscalls::exec_cell(code_hash, hash_type, offset, length, argv)
+    syscalls::exec_cell(code_hash, hash_type, argv)
 }
 
 /// Spawn a cell in cell dep.

--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -625,11 +625,14 @@ pub fn encode_hex(data: &[u8]) -> CString {
     CString::new(s).unwrap()
 }
 
-pub fn decode_hex(data: &CStr) -> Vec<u8> {
+pub fn decode_hex(data: &CStr) -> Result<Vec<u8>, SysError> {
     let data = data.to_str().unwrap();
+    if data.len() & 1 != 0 {
+        return Err(SysError::Encoding);
+    }
     (0..data.len())
         .step_by(2)
-        .map(|i| u8::from_str_radix(&data[i..i + 2], 16).unwrap())
+        .map(|i| u8::from_str_radix(&data[i..i + 2], 16).map_err(|_| SysError::Encoding))
         .collect()
 }
 
@@ -643,7 +646,7 @@ pub fn decode_hex(data: &CStr) -> Vec<u8> {
 ///            - if the parameter you want to pass can be represented by a string:
 ///              - CStr::from_bytes_with_nul(b"arg0\0").unwrap();
 ///              - CString::new("arg0").unwrap().as_c_str();
-///            - if you want to pass a piece of bytes data:
+///            - if you want to pass a piece of bytes data, you may encode it to hexadecimal string or other format:
 ///              - high_level::encode_hex(&vec![0xff, 0xfe, 0xfd]);
 pub fn exec_cell(
     code_hash: &[u8],
@@ -675,7 +678,7 @@ pub fn exec_cell(
 ///            - if the parameter you want to pass can be represented by a string:
 ///              - CStr::from_bytes_with_nul(b"arg0\0").unwrap();
 ///              - CString::new("arg0").unwrap().as_c_str();
-///            - if you want to pass a piece of bytes data:
+///            - if you want to pass a piece of bytes data, you may encode it to hexadecimal string or other format:
 ///              - high_level::encode_hex(&vec![0xff, 0xfe, 0xfd]);
 /// * `memory_limit` - a number between 1 and 8.
 ///                  - note each tick represents an additional 0.5M of memory.

--- a/src/syscalls/simulator.rs
+++ b/src/syscalls/simulator.rs
@@ -241,8 +241,6 @@ pub fn exec(
 pub fn exec_cell(
     code_hash: &[u8],
     hash_type: ScriptHashType,
-    offset: u32,
-    length: u32,
     argv: &[&CStr],
 ) -> Result<Infallible, SysError> {
     let argc = argv.len();
@@ -253,8 +251,8 @@ pub fn exec_cell(
     let ret = sim::ckb_exec_cell(
         code_hash.as_ptr(),
         hash_type as u8,
-        offset,
-        length,
+        0,
+        0,
         argc as i32,
         argv_ptr.as_ptr(),
     );


### PR DESCRIPTION
- Considering that non-zero offset and length of `exec_cell` are almost never used, we removed these two parameters in the high level `exec` api. But you can still use them in the low level `exec`. 
- Add `encode_hex()` and `decode_hex()`
- Update capsule to v0.10.0