### PR TITLE
doc: Update debug macro doc with latest usage in release build

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -3,8 +3,15 @@
 /// Output a debug message.
 ///
 /// This macro only compiled under debug build and does nothing in release build. To debug the release build,
-/// append the `--cfg debug_assertions` arguments to `cargo build`. For users of Capsule, the debug macro can
-/// be enabled in the release build by running `capsule build --release --debug-output`.
+/// include `--cfg debug_assertions` in the environment variable `RUSTFLAGS` before calling `cargo build`.
+/// For example:
+///
+/// ```
+/// RUSTFLAGS="--cfg debug_assertions" cargo build --release --target=riscv64imac-unknown-none-elf
+/// ```
+///
+/// For users of Capsule, the debug macro can be enabled in the release build by running
+/// `capsule build --release --debug-output`.
 ///
 /// Notice: to see the debug output, you must turn on `ckb_script` debugging log in the CKB node configuration
 /// like this:


### PR DESCRIPTION
Following the previous comments, one might naturally try:

```
cargo build --release --cfg debug_assertions
```

But this is not working now. Capsule these days also put the `cfg` part in the environment variable, we might want to update the commment doc here.