### PR TITLE
fix: Only alter panic handler in riscv64 target

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -50,6 +50,7 @@ macro_rules! entry {
             "ecall",
         );
 
+        #[cfg(target_arch = "riscv64")]
         #[panic_handler]
         fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
             $crate::debug!("{}", panic_info);


### PR DESCRIPTION
Previously the panic handler is inserted in all targets. This would make clippy complain about the following error:

```
error[E0152]: found duplicate lang item `panic_impl`
```

By only altering panic handler in riscv64 target, the error would now go away