### PR TITLE
Fix cargo resolver warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ gcd = "2.3.0"
 
 [workspace]
 exclude = ["test"]
+resolver = "2"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["ckb-std-tests", "exec-callee", "exec-caller", "exec-caller-by-code-hash", "spawn-caller", "spawn-caller-by-code-hash", "spawn-callee"]
+resolver = "2"
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
remove following warnings:
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`