### PR TITLE
Update ckb-x64-simulator to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cc = "1.0"
 [dependencies]
 ckb-types = { package = "ckb-gen-types", version = "0.116", default-features = false, optional = true }
 buddy-alloc = { version = "0.5.0", optional = true }
-ckb-x64-simulator = { version = "0.8", optional = true }
+ckb-x64-simulator = { version = "0.9.1", optional = true }
 gcd = "2.3.0"
 log = { version = "0.4.21", optional = true, default-features = false }
 


### PR DESCRIPTION
To support syscall `exec`, see https://github.com/nervosnetwork/ckb-x64-simulator/pull/10