### PR TITLE
Use ubuntu 22.04 image for cross

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -2,4 +2,4 @@
 default-target = "riscv64imac-unknown-none-elf"
 
 [target.riscv64imac-unknown-none-elf]
-image = "nervos/ckb-riscv-gnu-toolchain:focal-20230214"
+image = "nervos/ckb-riscv-gnu-toolchain:jammy-20230214"

--- a/contracts/Cross.toml
+++ b/contracts/Cross.toml
@@ -2,4 +2,4 @@
 default-target = "riscv64imac-unknown-none-elf"
 
 [target.riscv64imac-unknown-none-elf]
-image = "nervos/ckb-riscv-gnu-toolchain:focal-20230214"
+image = "nervos/ckb-riscv-gnu-toolchain:jammy-20230214"

--- a/test/shared-lib/Makefile
+++ b/test/shared-lib/Makefile
@@ -5,8 +5,7 @@ OBJCOPY := $(TARGET)-objcopy
 CFLAGS := -fPIC -O3 -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/libc -I deps -I deps/molecule -I c -I build -I deps/secp256k1/src -I deps/secp256k1 -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
 LDFLAGS := -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections
 
-# docker pull nervos/ckb-riscv-gnu-toolchain:gnu-focal-20230214
-BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:7bc4e566f293b6c3d9740cf04fc5861b2f0acc268ca3a025fcf9446f1ab5f27d
+BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain:gnu-jammy-20230214
 
 all-via-docker:
 	docker run --rm -v `pwd`:/code ${BUILDER_DOCKER} bash -c "cd /code && make shared-lib.so"


### PR DESCRIPTION
In the Ubuntu 24.04 host environment, using cross will result in an error:

`/lib/x86_64-linux-gnu/libc.so.6: version glibc_2.33 not found;`

Upgrading the image to 22.04 can solve this problem