### PR TITLE
Update actions/checkout@v3 to v4

### DIFF
--- a/.github/workflows/develop-clang.yml
+++ b/.github/workflows/develop-clang.yml
@@ -8,7 +8,7 @@ jobs:
   develop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Deps

--- a/.github/workflows/develop-rust.yml
+++ b/.github/workflows/develop-rust.yml
@@ -8,7 +8,7 @@ jobs:
   develop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Deps


### PR DESCRIPTION
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
