### PR TITLE
Handling warnings under arch

### DIFF
--- a/src/syscalls/native.rs
+++ b/src/syscalls/native.rs
@@ -558,7 +558,8 @@ pub fn current_cycles() -> u64 {
 pub fn exec(index: usize, source: Source, place: usize, bounds: usize, argv: &[&CStr]) -> u64 {
     // https://www.gnu.org/software/libc/manual/html_node/Program-Arguments.html
     let argc = argv.len();
-    let argv_ptr: alloc::vec::Vec<*const i8> = argv.iter().map(|e| e.as_ptr()).collect();
+    // On some platforms, CStr may be u8, adding as *const i8 is used to reduce such warnings
+    let argv_ptr: alloc::vec::Vec<*const i8> = argv.iter().map(|e| e.as_ptr() as *const i8).collect();
     unsafe {
         syscall(
             index as u64,


### PR DESCRIPTION
On some platforms, `CStr` may be `u8`, adding `as *const i8` is used to reduce such warnings.