### PR TITLE
Added tips about dynamic libraries

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,7 +265,9 @@ dependencies = [
  "blake2b-ref",
  "bytes",
  "ckb-std",
+ "lazy_static",
  "log",
+ "spin",
 ]
 
 [[package]]
@@ -450,6 +458,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -465,6 +476,16 @@ checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -551,15 +572,24 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -633,6 +663,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +735,15 @@ name = "spawn-caller-by-code-hash"
 version = "0.1.0"
 dependencies = [
  "ckb-std",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/contracts/ckb-std-tests/Cargo.toml
+++ b/contracts/ckb-std-tests/Cargo.toml
@@ -9,4 +9,6 @@ edition = "2021"
 ckb-std = { path = "../../", features = ["build-with-clang", "dlopen-c", "log"] }
 blake2b-ref = { version = "0.3", default-features = false }
 bytes = { version = "1.7", default-features = false }
+lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
 log = { version = "0.4", default-features = false }
+spin = { version = "0.9" }

--- a/contracts/ckb-std-tests/src/entry.rs
+++ b/contracts/ckb-std-tests/src/entry.rs
@@ -805,6 +805,19 @@ pub fn main() -> Result<(), Error> {
     test_query();
     test_calc_data_hash();
 
+    // Context should not be dropped.
+    #[cfg(target_arch = "riscv64")]
+    #[allow(deprecated)]
+    let mut old_context = unsafe { ContextTypeOld::new() };
+    #[cfg(target_arch = "riscv64")]
+    test_dynamic_loading(&mut old_context);
+
+    // Context should not be dropped.
+    #[cfg(target_arch = "riscv64")]
+    let mut context = unsafe { ContextType::new() };
+    #[cfg(target_arch = "riscv64")]
+    test_dynamic_loading_c_impl(&mut context);
+
     test_vm_version();
     test_current_cycles();
     test_since();
@@ -813,16 +826,6 @@ pub fn main() -> Result<(), Error> {
         test_atomic();
         test_atomic2();
         test_log();
-    }
-
-    #[cfg(target_arch = "riscv64")]
-    unsafe {
-        let mut context = ContextType::new();
-        #[allow(deprecated)]
-        let mut old_context = ContextTypeOld::new();
-
-        test_dynamic_loading(&mut old_context);
-        test_dynamic_loading_c_impl(&mut context);
     }
 
     Ok(())

--- a/test/simulator/Cargo.toml
+++ b/test/simulator/Cargo.toml
@@ -19,7 +19,9 @@ path = "src/exec_callee.rs"
 ckb-std = { path = "../..", default-features=false, features = ["allocator", "calc-hash", "ckb-types", "libc", "native-simulator"] }
 blake2b-ref = { version = "0.3", default-features = false }
 bytes = { version = "1.6.0", default-features = false }
+lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
 log = { version = "0.4.17", default-features = false }
+spin = { version = "0.9" }
 
 [dev-dependencies]
 libloading = "0.8.4"


### PR DESCRIPTION


The [comments](https://github.com/nervosnetwork/ckb-std/blob/master/src/dynamic_loading.rs#L40-L41) says that context cannot be dropped, but the [test cases](https://github.com/nervosnetwork/ckb-std/blob/ed3c9513576edccc2772a06aae624adfda0099be/contracts/ckb-std-tests/src/entry.rs#L808-L816) we wrote before have always been used incorrectly. Therefore, tips are added to the test cases.