### PR TITLE
Align heap to 64 bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,14 @@ exclude = ["docs"]
 
 [package.metadata.docs.rs]
 # All features except simulator and rustc-dep-of-std.
-features = ["allocator", "ckb-types", "libc", "calc-hash", "build-with-clang", "dlopen-c"]
+features = [
+  "allocator",
+  "ckb-types",
+  "libc",
+  "calc-hash",
+  "build-with-clang",
+  "dlopen-c",
+]
 rustdoc-args = ["--cfg", "docsrs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -35,9 +42,11 @@ cc = "1.0"
 
 [dependencies]
 ckb-types = { package = "ckb-gen-types", version = "0.118", default-features = false, optional = true }
-ckb-hash = { version = "0.118", default-features = false, features = ["ckb-contract"], optional = true }
+ckb-hash = { version = "0.118", default-features = false, features = [
+  "ckb-contract",
+], optional = true }
 
-buddy-alloc = { version = "0.5", optional = true }
+buddy-alloc = { version = "0.6", optional = true }
 ckb-x64-simulator = { version = "0.9", optional = true }
 gcd = "2.3"
 log = { version = "0.4", optional = true, default-features = false }


### PR DESCRIPTION
https://github.com/jjyr/buddy-alloc/issues/18#issuecomment-2413073000

buddy-alloc 0.5 uses `ptr#write_aligned` which costs more cycles than `write`.

In 0.6 we assume the heap memory is aligned to 64 bytes, so we can switch to `ptr::write`.