### PR TITLE
Add new macros to allow assertions with custom exit code

### DIFF
--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,6 +1,8 @@
 use core::fmt::Debug;
 
-pub static mut __PANIC_EXIT_CODE: i8 = -1;
+const DEFAULT_PANIC_EXIT_CODE: i8 = -1;
+
+pub static mut __PANIC_EXIT_CODE: i8 = DEFAULT_PANIC_EXIT_CODE;
 
 pub fn set_panic_exit_code(code: i8) {
     unsafe {
@@ -13,6 +15,7 @@ macro_rules! set_error_assert {
     ($code:expr, $($arg:tt)*) => {{
         $crate::asserts::set_panic_exit_code($code);
         assert!($($arg)*);
+        $crate::asserts::set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
     }};
 }
 
@@ -21,10 +24,13 @@ macro_rules! set_error_assert_eq {
     ($code:expr, $($arg:tt)*) => {{
         $crate::asserts::set_panic_exit_code($code);
         assert_eq!($($arg)*);
+        $crate::asserts::set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
     }};
 }
 
 pub fn set_error_expect<C: Into<i8>, T, E: Debug>(c: C, r: Result<T, E>, msg: &str) -> T {
     set_panic_exit_code(c.into());
-    r.expect(msg)
+    let t = r.expect(msg);
+    set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+    t
 }

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -13,7 +13,9 @@ pub fn set_panic_exit_code(code: i8) {
 #[macro_export]
 macro_rules! assert {
     ($code:expr, $($arg:tt)*) => {{
-        $crate::asserts::set_panic_exit_code($code);
+        #[allow(trivial_numeric_casts)]
+        #[allow(clippy::unnecessary_cast)]
+        $crate::asserts::set_panic_exit_code($code as i8);
         core::assert!($($arg)*);
         $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
     }};
@@ -22,7 +24,9 @@ macro_rules! assert {
 #[macro_export]
 macro_rules! assert_eq {
     ($code:expr, $($arg:tt)*) => {{
-        $crate::asserts::set_panic_exit_code($code);
+        #[allow(trivial_numeric_casts)]
+        #[allow(clippy::unnecessary_cast)]
+        $crate::asserts::set_panic_exit_code($code as i8);
         core::assert_eq!($($arg)*);
         $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
     }};
@@ -31,7 +35,9 @@ macro_rules! assert_eq {
 #[macro_export]
 macro_rules! assert_ne {
     ($code:expr, $($arg:tt)*) => {{
-        $crate::asserts::set_panic_exit_code($code);
+        #[allow(trivial_numeric_casts)]
+        #[allow(clippy::unnecessary_cast)]
+        $crate::asserts::set_panic_exit_code($code as i8);
         core::assert_ne!($($arg)*);
         $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
     }};

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-const DEFAULT_PANIC_EXIT_CODE: i8 = -1;
+pub const DEFAULT_PANIC_EXIT_CODE: i8 = -1;
 
 pub static mut __PANIC_EXIT_CODE: i8 = DEFAULT_PANIC_EXIT_CODE;
 
@@ -15,7 +15,7 @@ macro_rules! set_error_assert {
     ($code:expr, $($arg:tt)*) => {{
         $crate::asserts::set_panic_exit_code($code);
         assert!($($arg)*);
-        $crate::asserts::set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+        $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
     }};
 }
 
@@ -24,7 +24,7 @@ macro_rules! set_error_assert_eq {
     ($code:expr, $($arg:tt)*) => {{
         $crate::asserts::set_panic_exit_code($code);
         assert_eq!($($arg)*);
-        $crate::asserts::set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+        $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
     }};
 }
 

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -11,26 +11,70 @@ pub fn set_panic_exit_code(code: i8) {
 }
 
 #[macro_export]
-macro_rules! set_error_assert {
+macro_rules! assert {
     ($code:expr, $($arg:tt)*) => {{
         $crate::asserts::set_panic_exit_code($code);
-        assert!($($arg)*);
+        core::assert!($($arg)*);
         $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
     }};
 }
 
 #[macro_export]
-macro_rules! set_error_assert_eq {
+macro_rules! assert_eq {
     ($code:expr, $($arg:tt)*) => {{
         $crate::asserts::set_panic_exit_code($code);
-        assert_eq!($($arg)*);
+        core::assert_eq!($($arg)*);
         $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
     }};
 }
 
-pub fn set_error_expect<C: Into<i8>, T, E: Debug>(c: C, r: Result<T, E>, msg: &str) -> T {
+#[macro_export]
+macro_rules! assert_ne {
+    ($code:expr, $($arg:tt)*) => {{
+        $crate::asserts::set_panic_exit_code($code);
+        core::assert_ne!($($arg)*);
+        $crate::asserts::set_panic_exit_code($crate::asserts::DEFAULT_PANIC_EXIT_CODE);
+    }};
+}
+
+pub fn expect_result<C: Into<i8>, T, E: Debug>(c: C, r: Result<T, E>, msg: &str) -> T {
     set_panic_exit_code(c.into());
     let t = r.expect(msg);
+    set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+    t
+}
+
+pub fn expect_err_result<C: Into<i8>, T: Debug, E>(c: C, r: Result<T, E>, msg: &str) -> E {
+    set_panic_exit_code(c.into());
+    let e = r.expect_err(msg);
+    set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+    e
+}
+
+pub fn unwrap_result<C: Into<i8>, T, E: Debug>(c: C, r: Result<T, E>) -> T {
+    set_panic_exit_code(c.into());
+    let t = r.unwrap();
+    set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+    t
+}
+
+pub fn unwrap_err_result<C: Into<i8>, T: Debug, E>(c: C, r: Result<T, E>) -> E {
+    set_panic_exit_code(c.into());
+    let e = r.unwrap_err();
+    set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+    e
+}
+
+pub fn expect_option<C: Into<i8>, T>(c: C, o: Option<T>, msg: &str) -> T {
+    set_panic_exit_code(c.into());
+    let t = o.expect(msg);
+    set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
+    t
+}
+
+pub fn unwrap_option<C: Into<i8>, T>(c: C, o: Option<T>) -> T {
+    set_panic_exit_code(c.into());
+    let t = o.unwrap();
     set_panic_exit_code(DEFAULT_PANIC_EXIT_CODE);
     t
 }

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,0 +1,30 @@
+use core::fmt::Debug;
+
+pub static mut __PANIC_EXIT_CODE: i8 = -1;
+
+pub fn set_panic_exit_code(code: i8) {
+    unsafe {
+        __PANIC_EXIT_CODE = code;
+    }
+}
+
+#[macro_export]
+macro_rules! set_error_assert {
+    ($code:expr, $($arg:tt)*) => {{
+        $crate::asserts::set_panic_exit_code($code);
+        assert!($($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! set_error_assert_eq {
+    ($code:expr, $($arg:tt)*) => {{
+        $crate::asserts::set_panic_exit_code($code);
+        assert_eq!($($arg)*);
+    }};
+}
+
+pub fn set_error_expect<C: Into<i8>, T, E: Debug>(c: C, r: Result<T, E>, msg: &str) -> T {
+    set_panic_exit_code(c.into());
+    r.expect(msg)
+}

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -54,7 +54,7 @@ macro_rules! entry {
         #[panic_handler]
         fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
             $crate::debug!("{}", panic_info);
-            $crate::syscalls::exit(-1)
+            $crate::syscalls::exit(unsafe { $crate::asserts::__PANIC_EXIT_CODE })
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 
 extern crate alloc;
 
+pub mod asserts;
 pub mod ckb_constants;
 #[doc(hidden)]
 pub mod debug;


### PR DESCRIPTION
This change adds 2 new macros & 1 utility functions, that allows one to set the return error code first, then runs assertions in Rust.

This allows us to get the benefit of both worlds: we could use assertion lines with decent debug message outputs, while at the same time we can also customize final exit code.