### PR TITLE
Update the signature of the load cell code

### DIFF
--- a/src/syscalls/stub.rs
+++ b/src/syscalls/stub.rs
@@ -105,7 +105,7 @@ pub fn load_cell_code(
 ) -> Result<usize, SysError> {
     let result = get().load_cell_code(buf_ptr, len, content_offset, content_size, index, source);
     match result {
-        Ok(()) => Ok(len),
+        Ok(_) => Ok(len),
         Err(e) => Err(e.into()),
     }
 }

--- a/src/syscalls/traits.rs
+++ b/src/syscalls/traits.rs
@@ -122,7 +122,7 @@ pub trait SyscallImpls {
         content_size: usize,
         index: usize,
         source: Source,
-    ) -> Result<(), Error> {
+    ) -> Result<Vec<MemoryPageResult>, Error> {
         build_result(self.syscall(
             buf_ptr as u64,
             len as u64,
@@ -132,6 +132,7 @@ pub trait SyscallImpls {
             source as u64,
             consts::SYS_LOAD_CELL_DATA_AS_CODE,
         ))
+        .and_then(|_| Ok(Vec::new()))
     }
     fn load_cell_data(
         &self,
@@ -429,7 +430,7 @@ pub fn syscall_to_impls<S: SyscallImpls + ?Sized>(
                 a4 as usize,
                 source,
             ) {
-                Ok(()) => 0,
+                Ok(_) => 0,
                 Err(e) => e.into(),
             }
         }
@@ -736,4 +737,12 @@ impl From<Error> for SysError {
             Error::Other(e) => SysError::Unknown(e),
         }
     }
+}
+
+/// MemoryPageResult captures response from load cell code.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MemoryPageResult {
+    pub page_start: u64,
+    pub data: [u8; 4096],
+    pub flag: u8,
 }


### PR DESCRIPTION
Allow `load_cell_code` to return a list of MemoryPageResult, indicating which memory pages it should or has modified.

Ref https://github.com/nervosnetwork/ckb-vm-contrib/pull/22#discussion_r2265510764